### PR TITLE
MT-663: Change log level from error to info when unabling to log ip address

### DIFF
--- a/src/Console/Commands/ProcessTrackings.php
+++ b/src/Console/Commands/ProcessTrackings.php
@@ -451,7 +451,7 @@ class ProcessTrackings extends \Illuminate\Console\Command
                         $data
                     ]);
             } catch (\Throwable $e) {
-                Log::error("railtracker4_ip_data: Unable to log ip address " . $newIpData->ipAddress);
+                Log::info("railtracker4_ip_data: Unable to log ip address " . $newIpData->ipAddress);
             }
         }
 


### PR DESCRIPTION
- Changed log level to info since it was flooding logs